### PR TITLE
Set Content-Type http.Call to JSON

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -13,6 +13,12 @@ import (
 
 // Call marshals the body to JSON and sends a HTTP request. Response is parsed as JSON.
 func Call(method string, rootURL string, path string, body interface{}, response interface{}, query map[string]string, headers map[string]string) (*http.Response, *errors.GenericError) {
+	// Set Content-Type to JSON
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	headers["Content-Type"] = "application/json"
+
 	// Setup default logging fields
 	defaultLog := log.WithFields(log.Fields{
 		"method":  method,

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -54,6 +54,7 @@ func Test_Call_200(t *testing.T) {
 		case "/test":
 			assert.Equal(t, "TESTMETHOD", req.Method)
 			assert.Equal(t, "query-success", req.URL.Query().Get("test-query"))
+			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
 			assert.Equal(t, "header-success", req.Header.Get("X-TEST"))
 			fmt.Fprint(res, `{"Response": "response sample"}`)
 			return true
@@ -92,6 +93,7 @@ func Test_Call_400(t *testing.T) {
 	testFunc := func(t *testing.T, res http.ResponseWriter, req *http.Request) bool {
 		switch req.URL.Path {
 		case "/test":
+			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
 			res.WriteHeader(400)
 			return true
 		}


### PR DESCRIPTION
Since `Call` is marshaling and parsing JSON, the `Content-Type` header should be set accordingly. Without the header, calls might raise `415 Unsupported Media Type`.