### PR TITLE
Logging: Remove "message" from fields

### DIFF
--- a/gin/audit_middleware_test.go
+++ b/gin/audit_middleware_test.go
@@ -35,17 +35,17 @@ func Test_AuditMiddleware_OperationSuccess(t *testing.T) {
 	expected := log.Fields{
 		"operator":        "test-operator",
 		"category":        logging.AuditCategoryAttempt,
-		"message":         logging.AuditMessageOperationAttempt,
 		"request_payload": fixtureBody,
 	}
 	assert.Equal(t, expected, actualAttempt)
+	assert.Equal(t, logging.AuditMessageOperationAttempt, hook.Entries[0].Message)
 
 	// Assert operation success
 	actualResult := testAssertAndDropDynamicEntryFields(t, hook.Entries[1])
 	expected["category"] = logging.AuditCategorySuccess
-	expected["message"] = logging.AuditMessageOperationSuccess
 	expected["response_payload"] = "test-response-body"
 	assert.Equal(t, expected, actualResult)
+	assert.Equal(t, logging.AuditMessageOperationSuccess, hook.Entries[1].Message)
 
 	// Assert combined
 	assert.Equal(t, hook.Entries[0].Data["operation_start_datetime"], hook.Entries[1].Data["operation_start_datetime"])
@@ -66,17 +66,17 @@ func Test_AuditMiddleware_OperationFail(t *testing.T) {
 	expected := log.Fields{
 		"operator":        "test-operator",
 		"category":        logging.AuditCategoryAttempt,
-		"message":         logging.AuditMessageOperationAttempt,
 		"request_payload": fixtureBody,
 	}
 	assert.Equal(t, expected, actualAttempt)
+	assert.Equal(t, logging.AuditMessageOperationAttempt, hook.Entries[0].Message)
 
 	// Assert operation fail
 	actualResult := testAssertAndDropDynamicEntryFields(t, hook.Entries[1])
 	expected["category"] = logging.AuditCategoryFail
-	expected["message"] = logging.AuditMessageOperationFail
 	expected["response_payload"] = "test-response-body"
 	assert.Equal(t, expected, actualResult)
+	assert.Equal(t, logging.AuditMessageOperationFail, hook.Entries[1].Message)
 
 	// Assert combined
 	assert.Equal(t, hook.Entries[0].Data["operation_start_datetime"], hook.Entries[1].Data["operation_start_datetime"])

--- a/logging/audit_helpers.go
+++ b/logging/audit_helpers.go
@@ -87,7 +87,7 @@ func logEvent(ctx context.Context, message string, category auditCategory, addit
 	// Log priority
 	// A lower priority (e.g. 3) will be overwritten by higher priority (e.g. 1)
 	//
-	// 1. Directly provided data: message and category
+	// 1. Directly provided data: category
 	// 2. Derived data: operation_time
 	// 3. Additionally provided data: additionalData
 	// 4. Metadata present in context: ctx
@@ -116,10 +116,10 @@ func logEvent(ctx context.Context, message string, category auditCategory, addit
 	deriveOperationTime(logFields)
 
 	// Add directly provided data
-	logFields["message"] = message
 	logFields["category"] = category
 
 	// Send audit to log
+	delete(logFields, "message")
 	log.WithFields(logFields).Info(message)
 }
 

--- a/logging/audit_helpers_logEvent_test.go
+++ b/logging/audit_helpers_logEvent_test.go
@@ -35,12 +35,12 @@ func Test_logEvent_WithContextAndAdditionalData_Success(t *testing.T) {
 	require.Len(t, hook.Entries, 1)
 	expectedData := log.Fields{
 		"category":               AuditCategorySuccess,
-		"message":                "test-message",
 		"test-additional-string": "test-additional-value",
 		"test-additional-int":    123,
 		"test-meta-key":          "test-meta-value",
 	}
 	assert.Equal(t, expectedData, hook.LastEntry().Data)
+	assert.Equal(t, "test-message", hook.LastEntry().Message)
 	hook.Reset()
 }
 
@@ -55,8 +55,8 @@ func Test_logEvent_Minimal_Success(t *testing.T) {
 	require.Len(t, hook.Entries, 1)
 	expectedData := log.Fields{
 		"category": AuditCategorySuccess,
-		"message":  "test-message",
 	}
 	assert.Equal(t, expectedData, hook.LastEntry().Data)
+	assert.Equal(t, "test-message", hook.LastEntry().Message)
 	hook.Reset()
 }


### PR DESCRIPTION
Logrus will rename the message field to "field.message", because it already has a field called "message".