### PR TITLE
Simplify signature of AddAuditInfo* calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ import (
     "github.com/skiprco/go-utils/http"
     "github.com/skiprco/go-utils/logging"
     "github.com/skiprco/go-utils/manifest"
+    "github.com/skiprco/go-utils/metadata"
     "github.com/skiprco/go-utils/validation"
 )
 ```
@@ -136,14 +137,11 @@ service := micro.NewService(
 service.Server().Init(server.WrapHandler(logging.AuditHandlerWrapper))
 service.Init()
 
-// Add additional logging info to the context
-ctx, genErr = logging.AddAuditInfo(ctx, Manifest.Name, "OrganisationID", req.ID)
+// AddAuditInfo prefixes the key with the service name, converts it to snake_case and adds the result to the context.
+func AddAuditInfo(ctx context.Context, key string, value string) (context.Context, *errors.GenericError) {}
 
-// Or using a map if you want to add more logging info
-ctx, genErr = logging.AddAuditInfoMap(ctx, Manifest.Name, metadata.Metadata{
-    "MembershipID": req.MembershipID,
-    "OrganisationID": req.OrganisationID,
-})
+// AddAuditInfoMap prefixes each metadata key with the service name, converts them to snake_case and adds the result to the context
+func AddAuditInfoMap(ctx context.Context, info map[string]string) (context.Context, *errors.GenericError) {}
 ```
 
 ### Manifest
@@ -157,28 +155,32 @@ if genErr != nil {
 
 ### Metadata
 ```go
+// Get tries to fetch the value stored with the provided key.
+// If meta is nil or key doesn't exist, an empty string is returned.
+func (meta Metadata) Get(key string) string {}
+
 // GetGinMetadata returns the currently defined metadata from the Gin context
-func GetGinMetadata(c *gin.Context) Metadata
+func GetGinMetadata(c *gin.Context) Metadata {}
 
 // UpdateGinMetadata upserts the metadata stored in the Gin context. Returns result of the merge.
-func UpdateGinMetadata(c *gin.Context, additionalMetadata Metadata) Metadata
+func UpdateGinMetadata(c *gin.Context, additionalMetadata Metadata) Metadata {}
 
 // SetGinMetadata upserts a single key/value pair in the Gin context. Returns result of the merge.
-func SetGinMetadata(c *gin.Context, key string, value string) Metadata
+func SetGinMetadata(c *gin.Context, key string, value string) Metadata {}
 
 // GetGoMicroMetadata returns the currently defined metadata from the go-micro context
-func GetGoMicroMetadata(ctx context.Context) (Metadata, *errors.GenericError)
+func GetGoMicroMetadata(ctx context.Context) (Metadata, *errors.GenericError) {}
 
 // UpdateGoMicroMetadata upserts the metadata stored in the go-micro context. Returns result of the merge.
-func UpdateGoMicroMetadata(ctx context.Context, additionalMetadata Metadata) (context.Context, Metadata, *errors.GenericError)
+func UpdateGoMicroMetadata(ctx context.Context, additionalMetadata Metadata) (context.Context, Metadata, *errors.GenericError) {}
 
 // SetGoMicroMetadata upserts a single key/value pair in the go-micro context. Returns result of the merge.
-func SetGoMicroMetadata(ctx context.Context, key string, value string) (context.Context, Metadata, *errors.GenericError)
+func SetGoMicroMetadata(ctx context.Context, key string, value string) (context.Context, Metadata, *errors.GenericError) {}
 
 // ConvertGinToGoMicro returns a context object with the metadata
 // set as go-micro metadata. This way the metadata can be accessed in
 // each microservices.
-func ConvertGinToGoMicro(c *gin.Context) context.Context
+func ConvertGinToGoMicro(c *gin.Context) context.Context {}
 ```
 
 ### Validation

--- a/logging/fixtures_test.go
+++ b/logging/fixtures_test.go
@@ -4,7 +4,8 @@ import "github.com/skiprco/go-utils/v2/metadata"
 
 func fixtureMetadata() metadata.Metadata {
 	return metadata.Metadata{
-		"test_service_test_key": "after_value",
+		"service_name":          "srv-test",
+		"srv_test_test_key":     "before_value",
 		"should_not_be_touched": "dont_touch_me",
 	}
 }

--- a/logging/go_micro_AddAuditInfoMap_test.go
+++ b/logging/go_micro_AddAuditInfoMap_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	microMeta "github.com/micro/go-micro/v2/metadata"
+	"github.com/skiprco/go-utils/v2/errors"
 	"github.com/skiprco/go-utils/v2/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,15 +16,15 @@ func Test_AddAuditInfoMap_WithData(t *testing.T) {
 	ctx, _, _ := metadata.UpdateGoMicroMetadata(context.Background(), fixtureMetadata())
 
 	// Call helper
-	ctx, genErr := AddAuditInfoMap(ctx, "TestService", metadata.Metadata{
+	ctx, genErr := AddAuditInfoMap(ctx, metadata.Metadata{
 		"TestKey": "after_value",
 		"NewKey":  "new_value",
 	})
 
 	// Assert results
 	expected := fixtureMetadata()
-	expected["test_service_test_key"] = "after_value"
-	expected["test_service_new_key"] = "new_value"
+	expected["srv_test_test_key"] = "after_value"
+	expected["srv_test_new_key"] = "new_value"
 	require.Nil(t, genErr)
 	meta, genErr := metadata.GetGoMicroMetadata(ctx)
 	require.Nil(t, genErr)
@@ -34,11 +36,32 @@ func Test_AddAuditInfoMap_Nil(t *testing.T) {
 	ctx, _, _ := metadata.UpdateGoMicroMetadata(context.Background(), fixtureMetadata())
 
 	// Call helper
-	ctx, genErr := AddAuditInfoMap(ctx, "TestService", nil)
+	ctx, genErr := AddAuditInfoMap(ctx, nil)
 
 	// Assert results
 	require.Nil(t, genErr)
 	meta, genErr := metadata.GetGoMicroMetadata(ctx)
 	require.Nil(t, genErr)
 	assert.Equal(t, fixtureMetadata(), meta)
+}
+
+func Test_AddAuditInfoMap_InvalidMeta(t *testing.T) {
+	// Setup test data
+	ctx := microMeta.Set(context.Background(), metadata.GoMicroMetadataKey, "invalid")
+
+	// Call helper
+	ctx, genErr := AddAuditInfoMap(ctx, nil)
+
+	// Assert results
+	assert.NotNil(t, genErr)
+	assert.NotNil(t, ctx)
+}
+
+func Test_AddAuditInfoMap_ServiceNameNotSet(t *testing.T) {
+	// Call helper
+	ctx, genErr := AddAuditInfoMap(context.Background(), nil)
+
+	// Assert results
+	assert.NotNil(t, ctx)
+	errors.AssertGenericError(t, genErr, 500, "service_name_not_found_in_context", nil)
 }

--- a/logging/go_micro_AddAuditInfo_test.go
+++ b/logging/go_micro_AddAuditInfo_test.go
@@ -4,16 +4,25 @@ import (
 	"context"
 	"testing"
 
+	microMeta "github.com/micro/go-micro/v2/metadata"
+	"github.com/skiprco/go-utils/v2/errors"
 	"github.com/skiprco/go-utils/v2/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_AddAuditInfo_New(t *testing.T) {
-	ctx, genErr := AddAuditInfo(context.Background(), "Test", "test_key", "test_value")
+	// Setup test data
+	ctx, _, _ := metadata.SetGoMicroMetadata(context.Background(), "service_name", "srv-test")
+
+	// Call helper
+	ctx, genErr := AddAuditInfo(ctx, "test_key", "test_value")
 
 	// Assert results
-	expected := metadata.Metadata{"test_test_key": "test_value"}
+	expected := metadata.Metadata{
+		"service_name":      "srv-test",
+		"srv_test_test_key": "test_value",
+	}
 	require.Nil(t, genErr)
 	meta, genErr := metadata.GetGoMicroMetadata(ctx)
 	require.Nil(t, genErr)
@@ -25,11 +34,34 @@ func Test_AddAuditInfo_Overwrite(t *testing.T) {
 	ctx, _, _ := metadata.UpdateGoMicroMetadata(context.Background(), fixtureMetadata())
 
 	// Call helper
-	ctx, genErr := AddAuditInfo(ctx, "TestService", "test_key", "after_value")
+	ctx, genErr := AddAuditInfo(ctx, "test_key", "after_value")
 
 	// Assert results
+	expected := fixtureMetadata()
+	expected["srv_test_test_key"] = "after_value"
 	require.Nil(t, genErr)
 	meta, genErr := metadata.GetGoMicroMetadata(ctx)
 	require.Nil(t, genErr)
-	assert.Equal(t, fixtureMetadata(), meta)
+	assert.Equal(t, expected, meta)
+}
+
+func Test_AddAuditInfo_InvalidMeta(t *testing.T) {
+	// Setup test data
+	ctx := microMeta.Set(context.Background(), metadata.GoMicroMetadataKey, "invalid")
+
+	// Call helper
+	ctx, genErr := AddAuditInfo(ctx, "test_key", "test_value")
+
+	// Assert results
+	assert.NotNil(t, genErr)
+	assert.NotNil(t, ctx)
+}
+
+func Test_AddAuditInfo_ServiceNameNotSet(t *testing.T) {
+	// Call helper
+	ctx, genErr := AddAuditInfo(context.Background(), "test_key", "test_value")
+
+	// Assert results
+	assert.NotNil(t, ctx)
+	errors.AssertGenericError(t, genErr, 500, "service_name_not_found_in_context", nil)
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,4 @@
+package logging
+
+const errDomain = "go-utils"
+const errSubDomain = "logging"

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -20,6 +20,18 @@ const errSubDomain = "metadata"
 // This type will be the same even when using different packages (gin, go-micro, ...)
 type Metadata map[string]string
 
+// Get tries to fetch the value stored with the provided key.
+// If meta is nil or key doesn't exist, an empty string is returned.
+func (meta Metadata) Get(key string) string {
+	if meta == nil {
+		return ""
+	}
+
+	// Value will automatically default to an empty string with this syntax
+	value, _ := meta[key]
+	return value
+}
+
 // ========================================
 // =                  GOB                 =
 // ========================================

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -9,6 +9,23 @@ import (
 )
 
 // ========================================
+// =                COMMON                =
+// ========================================
+func Test_Get_Found(t *testing.T) {
+	meta := Metadata{"test_key": "test_value"}
+	assert.Equal(t, "test_value", meta.Get("test_key"))
+}
+
+func Test_Get_NotFound(t *testing.T) {
+	assert.Equal(t, "", Metadata{}.Get("test_key"))
+}
+
+func Test_Get_Nil(t *testing.T) {
+	var meta Metadata = nil
+	assert.Equal(t, "", meta.Get("test_key"))
+}
+
+// ========================================
 // =              ROUNDTRIPS              =
 // ========================================
 


### PR DESCRIPTION
**Note:** This is a breaking change. But since it's not used anywhere yet, I decided to stay with the current mayor version.

This change uses the `service_name` from the context instead of receiving it as parameter. This saves us from having to either hardcode the name or having to pass the manifest around in the service.