### PR TITLE
Include response body on response_code_is_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,15 @@ genErr := http.Call("POST", "https://skipr.co", "users", users, CreateUserRespon
 file = []byte{...}
 httpResponse, genErr := http.CallRaw("POST", "https://skipr.co", "files", file, nil, nil)
 
-// In case the server returns an error code (>= 300), the http.Response is still returned.
-// This way, you can translate the body to a more specific error using below setup
+// In case the server returns an error code (>= 300), the response body is present on
+// the error meta as key "response_body". Also, the full response will still be returned.
+// This way, you can translate the body to a more specific error using below setup.
 res, genErr := http.Call("POST", "https://skipr.co", "/test", request, response, nil, nil)
 if genErr != nil {
     if genErr.SubDomainCode != "response_code_is_error" {
         return nil, genErr
     }
-    return nil, translateResponseToSpecificError(res)
+    return nil, translateResponseToSpecificError(genErr.Meta["response_body"])
 }
 ```
 

--- a/errors/genericError.go
+++ b/errors/genericError.go
@@ -29,6 +29,11 @@ func (e GenericError) GetDetailString() string {
 	// Build meta string
 	metaList := []string{}
 	for key, value := range e.Meta {
+		// Replace restricted characters = and ;
+		value = strings.ReplaceAll(value, "=", "_")
+		value = strings.ReplaceAll(value, ";", "_")
+
+		// Build metadata pair
 		metaList = append(metaList, fmt.Sprintf("%s=%s", key, value))
 	}
 

--- a/errors/genericError_test.go
+++ b/errors/genericError_test.go
@@ -23,13 +23,21 @@ func TestGenericError_GetDetailStringWithMeta(t *testing.T) {
 	SetupDefaults(defaultMeta)
 
 	// Get error string
-	meta := map[string]string{"additional": "success"}
+	meta := map[string]string{
+		"additional":           "success",
+		"restricted_equal":     "succ=ess",
+		"restricted_semicolon": "succ;ess",
+		"restricted_mixed":     "s=u;ccess",
+	}
 	detailString := NewGenericError(418, "test_domain", "test_subdomain", "test_error", meta).GetDetailString()
 
 	// Assert result
 	assert.Regexp(t, `^test_domain/test_subdomain/test_error/.+=.+(;.+?=.+?)*$`, detailString)
 	assert.Contains(t, detailString, `provider=test_provider`)
 	assert.Contains(t, detailString, `additional=success`)
+	assert.Contains(t, detailString, `restricted_equal=succ_ess`)
+	assert.Contains(t, detailString, `restricted_semicolon=succ_ess`)
+	assert.Contains(t, detailString, `restricted_mixed=s_u_ccess`)
 }
 
 func TestGenericError_ConvertToString(t *testing.T) {

--- a/http/http.go
+++ b/http/http.go
@@ -12,6 +12,24 @@ import (
 )
 
 // Call marshals the body to JSON and sends a HTTP request. Response is parsed as JSON.
+//
+// Raises
+//
+// - 500/marshal_request_body_failed: Failed to marshal request body to JSON
+//
+// - 421/send_http_request_failed: Failed to send request (e.g. server unreachable)
+//
+// - 421/read_response_body_failed: Failed to read response body (only tried if response code is < 300)
+//
+// - 500/read_response_body_failed: Failed to read response body into a string (only tried if response code is >= 300)
+//
+// - dyn/response_code_is_error: Server returned an error code.
+// In case the full response will be returned. Also the response body is present on
+// the error meta as key "response_body". This way, you can translate the body to a more
+// specific error in an easy way. When you miss a translation, the full body is present on the
+// error for easier debugging.
+//
+// - 421/parse_response_body_failed: Failed to parse JSON response into provided response interface
 func Call(method string, rootURL string, path string, body interface{}, response interface{}, query map[string]string, headers map[string]string) (*http.Response, *errors.GenericError) {
 	// Set Content-Type to JSON
 	if headers == nil {
@@ -72,6 +90,18 @@ func Call(method string, rootURL string, path string, body interface{}, response
 }
 
 // CallRaw sends a HTTP request without modifying the body
+//
+// Raises
+//
+// - 421/send_http_request_failed: Failed to send request (e.g. server unreachable)
+//
+// - 500/read_response_body_failed: Failed to read response body into a string (only tried if response code is >= 300)
+//
+// - dyn/response_code_is_error: Server returned an error code.
+// In case the full response will be returned. Also the response body is present on
+// the error meta as key "response_body". This way, you can translate the body to a more
+// specific error in an easy way. When you miss a translation, the full body is present on the
+// error for easier debugging.
 func CallRaw(method string, rootURL string, path string, body []byte, query map[string]string, headers map[string]string) (*http.Response, *errors.GenericError) {
 	// Create request
 	req := createRequest(method, rootURL, path, body, query, headers)

--- a/http/http.go
+++ b/http/http.go
@@ -134,17 +134,19 @@ func sendRequest(req *http.Request) (*http.Response, *errors.GenericError) {
 	switch {
 	// API responded with an error
 	case res.StatusCode >= 300:
-		body, genErr := duplicateAndReturnResponseBody(res, traceID)
+		bodyBytes, genErr := duplicateAndReturnResponseBody(res, traceID)
 		if genErr != nil {
 			return nil, genErr
 		}
+		body := string(bodyBytes)
 
 		// Log and return error
 		log.WithFields(log.Fields{
-			"body":     string(body),
+			"body":     body,
 			"trace_id": traceID,
 		}).Warn("HTTP response code is error")
-		return res, errors.NewGenericError(res.StatusCode, "go_utils", "common", "response_code_is_error", nil)
+		meta := map[string]string{"response_body": body}
+		return res, errors.NewGenericError(res.StatusCode, "go_utils", "common", "response_code_is_error", meta)
 
 	// API responded with 2xx Success
 	default:

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -118,7 +118,7 @@ func Test_Call_400(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "error_during_test", string(body))
 	assert.Equal(t, &responseSample{}, response)
-	errors.AssertGenericError(t, genErr, 400, "response_code_is_error", nil)
+	errors.AssertGenericError(t, genErr, 400, "response_code_is_error", map[string]string{"response_body": "error_during_test"})
 }
 
 func Test_Call_MarshalRequestBodyFailed_Failure(t *testing.T) {


### PR DESCRIPTION
This change consists of 3 changes:
1. Errors: Clean the metadata values to ensure they don't contain the delimiters we use for the metadata (`=` and `;`)
2. HTTP: Include the response body as metadata value on error `response_code_is_error`
3. Quite some documentation

Requested by https://app.clickup.com/t/ceuvgf