### PR TITLE
Metadata: Add GetUserIDFromGoMicroMeta helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ func SetGinMetadata(c *gin.Context, key string, value string) Metadata {}
 // GetGoMicroMetadata returns the currently defined metadata from the go-micro context
 func GetGoMicroMetadata(ctx context.Context) (Metadata, *errors.GenericError) {}
 
+// GetUserIDFromGoMicroMeta extracts the user ID from the metadata of go-micro
+// and also returns the raw metadata for later use. Throws an error if unable
+// to read metadata or if user_id is not set.
+func GetUserIDFromGoMicroMeta(ctx context.Context, errorDomain string) (string, Metadata, *errors.GenericError) {}
+
 // UpdateGoMicroMetadata upserts the metadata stored in the go-micro context. Returns result of the merge.
 func UpdateGoMicroMetadata(ctx context.Context, additionalMetadata Metadata) (context.Context, Metadata, *errors.GenericError) {}
 

--- a/metadata/constants.go
+++ b/metadata/constants.go
@@ -1,0 +1,5 @@
+package metadata
+
+// ErrorUserIDNotInMeta is returned when you try to extract the user
+// from the metadata, but "user_id" is not set.
+const ErrorUserIDNotInMeta = "user_id_not_set_in_metadata"

--- a/metadata/go_micro_helpers.go
+++ b/metadata/go_micro_helpers.go
@@ -1,0 +1,30 @@
+package metadata
+
+import (
+	"context"
+
+	"github.com/skiprco/go-utils/v2/errors"
+)
+
+// GetUserIDFromGoMicroMeta extracts the user ID from the metadata of go-micro
+// and also returns the raw metadata for later use. Throws an error if unable
+// to read metadata or if user_id is not set.
+//
+// Raises
+//
+// - 500/user_id_not_set_in_metadata: The user ID key is not set in the metadata
+func GetUserIDFromGoMicroMeta(ctx context.Context, errorDomain string) (string, Metadata, *errors.GenericError) {
+	// Get user from metadata
+	meta, genErr := GetGoMicroMetadata(ctx)
+	if genErr != nil {
+		return "", meta, genErr
+	}
+
+	// Validate if user ID is set
+	userID := meta.Get("user_id")
+	if userID == "" {
+		return "", meta, errors.NewGenericError(500, errorDomain, "common", ErrorUserIDNotInMeta, nil)
+	}
+
+	return userID, meta, nil
+}


### PR DESCRIPTION
Already approved as part of https://github.com/skiprco/go-utils/pull/37
This PR is a backport of the GetUserIDFromGoMicroMeta helper.