### PR TITLE
Align and expose error message

### DIFF
--- a/auth/constants.go
+++ b/auth/constants.go
@@ -40,20 +40,6 @@ var roleMapOperatorAdmin = map[string]bool{
 }
 
 // =====================================
-// =               ERRORS              =
-// =====================================
-
-const errorDomain = "go-utils"
-const errorSubDomain = "auth"
-
-// ErrorNotEnoughPrivileges indicates the user tried to access a
-// resource for which it doesn't have enough privileges.
-const ErrorNotEnoughPrivileges = "not_enough_privileges"
-
-// ErrorUnknownRole indicates the checked role doesn't exist.
-const ErrorUnknownRole = "unknown_role"
-
-// =====================================
 // =               OTHER               =
 // =====================================
 

--- a/auth/errors.go
+++ b/auth/errors.go
@@ -1,0 +1,11 @@
+package auth
+
+const errorDomain = "go_utils"
+const errorSubDomain = "auth"
+
+// ErrorNotEnoughPrivileges indicates the user tried to access a
+// resource for which it doesn't have enough privileges.
+const ErrorNotEnoughPrivileges = "not_enough_privileges"
+
+// ErrorUnknownRole indicates the checked role doesn't exist.
+const ErrorUnknownRole = "unknown_role"

--- a/converters/country_code.go
+++ b/converters/country_code.go
@@ -263,15 +263,26 @@ func CountryCodes() map[string]string {
 }
 
 // CountryCodeToCountryName converts a country code to a country's name
+//
+// Raises
+//
+// - 404/country_not_found: Provided country code was not found
 func CountryCodeToCountryName(countryCode string) (string, *errors.GenericError) {
 	name, exists := CountryCodes()[countryCode]
 	if !exists {
-		return "", errors.NewGenericError(404, "go_utils", "common", "country_not_found", nil)
+		meta := map[string]string{"code": countryCode}
+		return "", errors.NewGenericError(404, errorDomain, errorSubDomain, ErrorCountryNotFound, meta)
 	}
 	return name, nil
 }
 
 // CountryNameToCountryCode converts a country name to a country's code, ignoring casing and accents
+//
+// Raises
+//
+// - 400/failed_to_normalise_string: Provided country name could not be normalised
+//
+// - 404/country_not_found: Provided country was not found
 func CountryNameToCountryCode(countryName string) (string, *errors.GenericError) {
 	// Clean input name
 	cleanName, genErr := NormaliseString(countryName)
@@ -286,5 +297,6 @@ func CountryNameToCountryCode(countryName string) (string, *errors.GenericError)
 			return code, nil
 		}
 	}
-	return "", errors.NewGenericError(404, "go_utils", "common", "country_not_found", nil)
+	meta := map[string]string{"name": countryName}
+	return "", errors.NewGenericError(404, errorDomain, errorSubDomain, ErrorCountryNotFound, meta)
 }

--- a/converters/errors.go
+++ b/converters/errors.go
@@ -1,9 +1,19 @@
 package converters
 
+const errorDomain = "go_utils"
+const errorSubDomain = "converters"
+
+// ErrorCountryNotFound indicates the specified country is not found.
+const ErrorCountryNotFound = "country_not_found"
+
 // ErrorInputIsNotPointer indicates a pointer was expected as input,
 // but the provided input is not a pointer.
 const ErrorInputIsNotPointer = "input_is_not_a_pointer"
 
 // ErrorPanicDuringSanitizeObject indicates we recovered from a panic
-// while running converters.SanitizeObject
+// while running converters.SanitizeObject.
 const ErrorPanicDuringSanitizeObject = "panic_during_sanitize_object"
+
+// ErrorFailedToNormaliseString indicates we failed to normalise the
+// provided string. More info is printed in the logs.
+const ErrorFailedToNormaliseString = "failed_to_normalise_string"

--- a/converters/phone_number.go
+++ b/converters/phone_number.go
@@ -1,14 +1,17 @@
 package converters
 
 import (
-	"github.com/skiprco/go-utils/v2/errors"
 	"regexp"
+
+	"github.com/skiprco/go-utils/v2/errors"
 )
 
-/**
-CleanPhoneNumber remove all non necessary code of a phone number
-Be aware that remove all non numeric char except the sign '+'
-*/
+// CleanPhoneNumber remove all non necessary code of a phone number
+// Be aware that remove all non numeric char except the sign '+'
+//
+// Raises
+//
+// Nothing: This function will never raise an error
 func CleanPhoneNumber(phoneNumber string) (string, *errors.GenericError) {
 	regExpression := regexp.MustCompile(`[^\+\d]`)
 	return regExpression.ReplaceAllLiteralString(phoneNumber, ""), nil

--- a/converters/sanitize.go
+++ b/converters/sanitize.go
@@ -26,9 +26,9 @@ func Sanitize(input string) string {
 //
 // Raises
 //
-// 500/input_is_not_a_pointer: Provided input is not a pointer
+// - 500/input_is_not_a_pointer: Provided input is not a pointer
 //
-// 500/panic_during_sanitize_object: A panic occured during sanitation
+// - 500/panic_during_sanitize_object: A panic occured during sanitation
 func SanitizeObject(input interface{}) (genErr *errors.GenericError) {
 	// Validate type of input
 	inputType := reflect.TypeOf(input)

--- a/converters/strings.go
+++ b/converters/strings.go
@@ -14,6 +14,10 @@ import (
 
 // NormaliseString removes all the accents from the letters in the string.
 // Based on https://twinnation.org/articles/33/remove-accents-from-characters-in-go
+//
+// Raises
+//
+// - 400/failed_to_normalise_string: Provided country name could not be normalised
 func NormaliseString(input string) (string, *errors.GenericError) {
 	// Normalise string
 	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
@@ -22,7 +26,7 @@ func NormaliseString(input string) (string, *errors.GenericError) {
 	// Handle error
 	if err != nil {
 		log.WithField("input", input).WithField("error", err).Error("Unable to normalise string")
-		return "", errors.NewGenericError(400, "go_utils", "common", "failed_to_normalise_string", nil)
+		return "", errors.NewGenericError(400, errorDomain, errorSubDomain, ErrorFailedToNormaliseString, nil)
 	}
 
 	// Normalise successful
@@ -41,9 +45,12 @@ func ToSnakeCase(input string) string {
 	return strings.ToLower(output)
 }
 
-/*
-CleanSpecialCharacters removes any character(included spaces) which is not a digit or a letter from the input
-*/
+// CleanSpecialCharacters removes any character(included spaces) which is
+// not a digit or a letter from the input.
+//
+// Raises
+//
+// Nothing: This function will never raise an error
 func CleanSpecialCharacters(input string) (string, *errors.GenericError) {
 	normalisedInput, genErr := NormaliseString(input)
 	if genErr != nil {

--- a/http/errors.go
+++ b/http/errors.go
@@ -1,0 +1,20 @@
+package http
+
+const errorDomain = "go_utils"
+const errorSubDomain = "http"
+
+// ErrorMarshalRequestBodyFailed indicates the marshaling of the request body to JSON failed.
+const ErrorMarshalRequestBodyFailed = "marshal_request_body_failed"
+
+// ErrorSendHTTPRequestFailed indicates sending the request failed (e.g. server unreachable).
+const ErrorSendHTTPRequestFailed = "send_http_request_failed"
+
+// ErrorReadResponseBodyFailed indicates reading the body to
+// bytes (response code < 300) or a string (response code >= 300) failed.
+const ErrorReadResponseBodyFailed = "read_response_body_failed"
+
+// ErrorResponseCodeIsError indicates the server returned an error response code.
+const ErrorResponseCodeIsError = "response_code_is_error"
+
+// ErrorParseResponseBodyFailed indicates parsing the JSON response into provided response interface failed.
+const ErrorParseResponseBodyFailed = "parse_response_body_failed"

--- a/http/http.go
+++ b/http/http.go
@@ -55,7 +55,7 @@ func Call(method string, rootURL string, path string, body interface{}, response
 		bodyBytes, err = json.Marshal(body)
 		if err != nil {
 			defaultLog.WithField("error", err).Error("Failed to marshal request body to JSON")
-			return nil, errors.NewGenericError(500, "go_utils", "common", "marshal_request_body_failed", nil)
+			return nil, errors.NewGenericError(500, errorDomain, errorSubDomain, ErrorMarshalRequestBodyFailed, nil)
 		}
 	}
 
@@ -77,14 +77,14 @@ func Call(method string, rootURL string, path string, body interface{}, response
 	resBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		traceLog.WithField("error", genErr.GetDetailString()).Error("Failed to read response body")
-		return nil, errors.NewGenericError(421, "go_utils", "common", "read_response_body_failed", nil)
+		return nil, errors.NewGenericError(421, errorDomain, errorSubDomain, ErrorReadResponseBodyFailed, nil)
 	}
 
 	// Unmarshal response
 	err = json.Unmarshal(resBody, response)
 	if err != nil {
 		traceLog.WithField("error", err).Error("Failed to parse response body from JSON")
-		return nil, errors.NewGenericError(421, "go_utils", "common", "parse_response_body_failed", nil)
+		return nil, errors.NewGenericError(421, errorDomain, errorSubDomain, ErrorParseResponseBodyFailed, nil)
 	}
 
 	// Return result
@@ -153,7 +153,7 @@ func sendRequest(req *http.Request) (*http.Response, *errors.GenericError) {
 	if err != nil {
 		log.WithField("error", err).Error("Failed to send HTTP request")
 		logging.LogHTTPRequestResponse(req, res, log.ErrorLevel, "Send request failed")
-		return nil, errors.NewGenericError(421, "go_utils", "common", "send_http_request_failed", nil)
+		return nil, errors.NewGenericError(421, errorDomain, errorSubDomain, ErrorSendHTTPRequestFailed, nil)
 	}
 
 	// Dump request for debugging
@@ -178,7 +178,7 @@ func sendRequest(req *http.Request) (*http.Response, *errors.GenericError) {
 			"trace_id": traceID,
 		}).Warn("HTTP response code is error")
 		meta := map[string]string{"response_body": body}
-		return res, errors.NewGenericError(res.StatusCode, "go_utils", "common", "response_code_is_error", meta)
+		return res, errors.NewGenericError(res.StatusCode, errorDomain, errorSubDomain, ErrorResponseCodeIsError, meta)
 
 	// API responded with 2xx Success
 	default:
@@ -196,7 +196,7 @@ func duplicateAndReturnResponseBody(res *http.Response, traceID string) ([]byte,
 			"error":    err,
 			"trace_id": traceID,
 		}).Error("Unable to read HTTP response body")
-		return nil, errors.NewGenericError(500, "go_utils", "common", "read_response_body_failed", nil)
+		return nil, errors.NewGenericError(500, errorDomain, errorSubDomain, ErrorReadResponseBodyFailed, nil)
 	}
 
 	// Replace body with new reader
@@ -212,7 +212,7 @@ func duplicateAndReturnResponseBody(res *http.Response, traceID string) ([]byte,
 func UnwrapResponseCodeIsError(ctx context.Context, genErr *errors.GenericError) (string, map[string]interface{}, bool) {
 	// Return original error if not code "response_code_is_error"
 	auditMeta := map[string]interface{}{}
-	if genErr.SubDomainCode != "response_code_is_error" {
+	if genErr.SubDomainCode != ErrorResponseCodeIsError {
 		return "", auditMeta, false
 	}
 

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -118,7 +118,7 @@ func Test_Call_400(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "error_during_test", string(body))
 	assert.Equal(t, &responseSample{}, response)
-	errors.AssertGenericError(t, genErr, 400, "response_code_is_error", map[string]string{"response_body": "error_during_test"})
+	errors.AssertGenericError(t, genErr, 400, ErrorResponseCodeIsError, map[string]string{"response_body": "error_during_test"})
 }
 
 func Test_Call_MarshalRequestBodyFailed_Failure(t *testing.T) {
@@ -130,7 +130,7 @@ func Test_Call_MarshalRequestBodyFailed_Failure(t *testing.T) {
 	// Assert results
 	assert.Nil(t, resp)
 	assert.Equal(t, &responseSample{}, response)
-	errors.AssertGenericError(t, genErr, 500, "marshal_request_body_failed", nil)
+	errors.AssertGenericError(t, genErr, 500, ErrorMarshalRequestBodyFailed, nil)
 }
 
 func Test_Call_SendRequestFailed_Failure(t *testing.T) {
@@ -141,7 +141,7 @@ func Test_Call_SendRequestFailed_Failure(t *testing.T) {
 	// Assert results
 	assert.Nil(t, resp)
 	assert.Equal(t, &responseSample{}, response)
-	errors.AssertGenericError(t, genErr, 421, "send_http_request_failed", nil)
+	errors.AssertGenericError(t, genErr, 421, ErrorSendHTTPRequestFailed, nil)
 }
 
 func Test_Call_ParseResponseBodyFailed_Failure(t *testing.T) {
@@ -168,7 +168,7 @@ func Test_Call_ParseResponseBodyFailed_Failure(t *testing.T) {
 	// Assert results
 	assert.Nil(t, resp)
 	assert.Equal(t, &responseSample{}, response)
-	errors.AssertGenericError(t, genErr, 421, "parse_response_body_failed", nil)
+	errors.AssertGenericError(t, genErr, 421, ErrorParseResponseBodyFailed, nil)
 }
 
 // ########################################
@@ -234,5 +234,5 @@ func Test_CallRaw_400(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, "error_during_test", string(body))
-	errors.AssertGenericError(t, genErr, 400, "response_code_is_error", nil)
+	errors.AssertGenericError(t, genErr, 400, ErrorResponseCodeIsError, nil)
 }

--- a/logging/errors.go
+++ b/logging/errors.go
@@ -1,0 +1,14 @@
+package logging
+
+const errorDomain = "go_utils"
+const errorSubDomain = "logging"
+
+// ErrorKeyNotFoundInContext indicates we expected to find a key in
+// the metadata of the context, but the key is not set.
+const ErrorKeyNotFoundInContext = "key_not_found_in_context"
+
+// ErrorUnableToDumpRequest indicates dumping the HTTP request failed
+const ErrorUnableToDumpRequest = "unable_to_dump_request"
+
+// ErrorUnableToDumpResponse indicates dumping the HTTP response failed
+const ErrorUnableToDumpResponse = "unable_to_dump_response"

--- a/logging/go_micro_AddAuditInfoMap_test.go
+++ b/logging/go_micro_AddAuditInfoMap_test.go
@@ -63,5 +63,6 @@ func Test_AddAuditInfoMap_ServiceNameNotSet(t *testing.T) {
 
 	// Assert results
 	assert.NotNil(t, ctx)
-	errors.AssertGenericError(t, genErr, 500, "service_name_not_found_in_context", nil)
+	meta := map[string]string{"key": "service_name"}
+	errors.AssertGenericError(t, genErr, 500, "key_not_found_in_context", meta)
 }

--- a/logging/go_micro_AddAuditInfo_test.go
+++ b/logging/go_micro_AddAuditInfo_test.go
@@ -63,5 +63,6 @@ func Test_AddAuditInfo_ServiceNameNotSet(t *testing.T) {
 
 	// Assert results
 	assert.NotNil(t, ctx)
-	errors.AssertGenericError(t, genErr, 500, "service_name_not_found_in_context", nil)
+	meta := map[string]string{"key": "service_name"}
+	errors.AssertGenericError(t, genErr, 500, "key_not_found_in_context", meta)
 }

--- a/logging/logHelpers.go
+++ b/logging/logHelpers.go
@@ -10,6 +10,12 @@ import (
 )
 
 // LogHTTPRequestResponse logs a HTTP request and response. Returns a trace ID to link follow-up logs.
+//
+// Raises
+//
+// - 500/unable_to_dump_request: Failed to dump to HTTP request
+//
+// - 500/unable_to_dump_response: Failed to dump to HTTP response
 func LogHTTPRequestResponse(request *http.Request, response *http.Response, logLevel log.Level, message string) (string, *errors.GenericError) {
 	// Generate trace ID
 	traceID := uuid.New()
@@ -19,7 +25,7 @@ func LogHTTPRequestResponse(request *http.Request, response *http.Response, logL
 	dumpReq, err := httputil.DumpRequest(request, true)
 	if err != nil {
 		traceLog.WithField("error", err).Error("Unable to dump HTTP request")
-		return traceID, errors.NewGenericError(500, "go_utils", "logging", "unable_to_dump_request", nil)
+		return traceID, errors.NewGenericError(500, errorDomain, errorSubDomain, ErrorUnableToDumpRequest, nil)
 	}
 
 	// Response body is already consumed.
@@ -32,7 +38,7 @@ func LogHTTPRequestResponse(request *http.Request, response *http.Response, logL
 		dumpResponseByte, err := httputil.DumpResponse(response, true)
 		if err != nil {
 			traceLog.WithField("error", err).Error("Unable to dump HTTP response")
-			return traceID, errors.NewGenericError(500, "go_utils", "logging", "unable_to_dump_response", nil)
+			return traceID, errors.NewGenericError(500, errorDomain, errorSubDomain, ErrorUnableToDumpResponse, nil)
 		}
 		dumpResponse = string(dumpResponseByte)
 	} else {

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,4 +1,0 @@
-package logging
-
-const errDomain = "go-utils"
-const errSubDomain = "logging"

--- a/manifest/errors.go
+++ b/manifest/errors.go
@@ -1,0 +1,10 @@
+package manifest
+
+const errorDomain = "go_utils"
+const errorSubDomain = "manifest"
+
+// ErrorManifestFileNotFound indicates the manifest file is not found or is not readable.
+const ErrorManifestFileNotFound = "manifest_file_not_found"
+
+// ErrorUnmarshalManifestFailed indicates parsing the manifest file as JSON failed.
+const ErrorUnmarshalManifestFailed = "unmarshal_manifest_failed"

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -26,6 +26,12 @@ type Manifest struct {
 }
 
 // LoadManifest loads a manifest file from the current directory
+//
+// Raises
+//
+// - 404/manifest_file_not_found: The manifest file is not found or is not readable
+//
+// - 500/unmarshal_manifest_failed: Failed to parse the manifest file as JSON
 func LoadManifest() (*Manifest, *errors.GenericError) {
 	// Setup logging
 	abs, _ := filepath.Abs(ManifestFileName)
@@ -35,7 +41,7 @@ func LoadManifest() (*Manifest, *errors.GenericError) {
 	file, err := ioutil.ReadFile(ManifestFileName)
 	if err != nil {
 		manifestLog.WithField("error", err).Error("Manifest file not found")
-		return nil, errors.NewGenericError(404, "go_utils", "manifest", "manifest_file_not_found", nil)
+		return nil, errors.NewGenericError(404, errorDomain, errorSubDomain, ErrorManifestFileNotFound, nil)
 	}
 
 	// Parse manifest
@@ -43,7 +49,7 @@ func LoadManifest() (*Manifest, *errors.GenericError) {
 	err = json.Unmarshal([]byte(file), manifest)
 	if err != nil {
 		manifestLog.WithField("error", err).Error("Failed to unmarshal manifest file")
-		return nil, errors.NewGenericError(500, "go_utils", "manifest", "unmarshal_manifest_failed", nil)
+		return nil, errors.NewGenericError(500, errorDomain, errorSubDomain, ErrorUnmarshalManifestFailed, nil)
 	}
 
 	// Load manifest successful

--- a/metadata/constants.go
+++ b/metadata/constants.go
@@ -1,5 +1,0 @@
-package metadata
-
-// ErrorUserIDNotInMeta is returned when you try to extract the user
-// from the metadata, but "user_id" is not set.
-const ErrorUserIDNotInMeta = "user_id_not_set_in_metadata"

--- a/metadata/errors.go
+++ b/metadata/errors.go
@@ -1,0 +1,12 @@
+package metadata
+
+const errorDomain = "go_utils"
+const errorSubDomain = "metadata"
+
+// ErrorUserIDNotInMeta indicates we tried to extract the user
+// from the metadata, but "user_id" is not set.
+const ErrorUserIDNotInMeta = "user_id_not_set_in_metadata"
+
+// ErrorDecodeGlobFromBase64Failed indicates decoding the metadata as glob
+// from the provided base64 string failed
+const ErrorDecodeGlobFromBase64Failed = "decode_glob_from_base64_failed"

--- a/metadata/go_micro.go
+++ b/metadata/go_micro.go
@@ -12,6 +12,12 @@ import (
 const GoMicroMetadataKey = "Metadata"
 
 // GetGoMicroMetadata returns the currently defined metadata from the go-micro context
+//
+// Raises
+//
+// - 400/decode_glob_from_base64_failed: Failed to decode the metadata as glob from the provided base64 string
+// (Note: This error can only occur if the metadata in the go-micro context got corrupted. Therefore this
+// error can never occur on a newly created context)
 func GetGoMicroMetadata(ctx context.Context) (Metadata, *errors.GenericError) {
 	// Extract encoded metadata from context
 	metaBase64, exists := metadata.Get(ctx, GoMicroMetadataKey)
@@ -26,6 +32,12 @@ func GetGoMicroMetadata(ctx context.Context) (Metadata, *errors.GenericError) {
 // UpdateGoMicroMetadata upserts the metadata stored in the go-micro context.
 // The provided metadata will be merged with the currently defined metadata.
 // Returns result of the merge.
+//
+// Raises
+//
+// - 400/decode_glob_from_base64_failed: Failed to decode the metadata as glob from the provided base64 string
+// (Note: This error can only occur if the metadata in the go-micro context got corrupted. Therefore this
+// error can never occur on a newly created context)
 func UpdateGoMicroMetadata(ctx context.Context, additionalMetadata Metadata) (context.Context, Metadata, *errors.GenericError) {
 	// Get current metadata
 	meta, genErr := GetGoMicroMetadata(ctx)
@@ -42,6 +54,12 @@ func UpdateGoMicroMetadata(ctx context.Context, additionalMetadata Metadata) (co
 // SetGoMicroMetadata upserts a single key/value pair in the go-micro context.
 // The provided metadata will be merged with the currently defined metadata.
 // Returns result of the merge.
+//
+// Raises
+//
+// - 400/decode_glob_from_base64_failed: Failed to decode the metadata as glob from the provided base64 string
+// (Note: This error can only occur if the metadata in the go-micro context got corrupted. Therefore this
+// error can never occur on a newly created context)
 func SetGoMicroMetadata(ctx context.Context, key string, value string) (context.Context, Metadata, *errors.GenericError) {
 	meta := Metadata{key: value}
 	return UpdateGoMicroMetadata(ctx, meta)

--- a/metadata/go_micro_helpers.go
+++ b/metadata/go_micro_helpers.go
@@ -23,7 +23,7 @@ func GetUserIDFromGoMicroMeta(ctx context.Context, errorDomain string) (string, 
 	// Validate if user ID is set
 	userID := meta.Get("user_id")
 	if userID == "" {
-		return "", meta, errors.NewGenericError(500, errorDomain, "common", ErrorUserIDNotInMeta, nil)
+		return "", meta, errors.NewGenericError(500, errorDomain, errorSubDomain, ErrorUserIDNotInMeta, nil)
 	}
 
 	return userID, meta, nil

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -85,6 +85,10 @@ func (meta Metadata) ToBase64() string {
 }
 
 // FromBase64 creates a metadata model from its base64 string equivalent
+//
+// Raises
+//
+// - 400/decode_glob_from_base64_failed: Failed to decode the metadata as glob from the provided base64 string
 func FromBase64(data string) (Metadata, *errors.GenericError) {
 	// Return empty metadata object when no data is provided
 	if data == "" {
@@ -95,7 +99,7 @@ func FromBase64(data string) (Metadata, *errors.GenericError) {
 	metaGob, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
 		log.WithField("error", err).WithField("data", data).Error("Failed to decode Gob bytes from base64 string")
-		return nil, errors.NewGenericError(400, errDomain, errSubDomain, "decode_glob_from_base64_failed", nil)
+		return nil, errors.NewGenericError(400, errDomain, errSubDomain, ErrorDecodeGlobFromBase64Failed, nil)
 	}
 
 	// Decode from binary to Metadata

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -1,0 +1,21 @@
+package validation
+
+const errorDomain = "go_utils"
+const errorSubDomain = "validation"
+
+// ErrorInvalidCountryCode provided country code is invalid.
+const ErrorInvalidCountryCode = "invalid_country_code"
+
+// ErrorNotAPhoneNumber indicates the provided phone number is not recognised as one.
+const ErrorNotAPhoneNumber = "not_a_phone_number"
+
+// ErrorInvalidPhoneNumber indicates the provided phone number has the correct format,
+// but is symantically incorrect.
+const ErrorInvalidPhoneNumber = "invalid_phone_number"
+
+// ErrorNotAMobilePhoneNumber indicates the provided phone number is not a mobile number.
+const ErrorNotAMobilePhoneNumber = "not_a_mobile_phone_number"
+
+// ErrorEndTimeBeforeStartTime indicates the provided end time is before
+// the provided start time. End time should be equal to or after start time.
+const ErrorEndTimeBeforeStartTime = "end_time_before_start_time"

--- a/validation/phone_number.go
+++ b/validation/phone_number.go
@@ -5,10 +5,20 @@ import (
 	"github.com/skiprco/go-utils/v2/errors"
 )
 
-const PhoneNumberInvalidCountryCodeMessage = "invalid country code"
+const phoneNumberInvalidCountryCodeMessage = "invalid country code"
 
 // ValidateAndFormatPhoneNumber checks if the provided phone number is valid.
-// If yes, it will format it to its E164 representation (e.g +32...)
+// If yes, it will format it to its E164 representation (e.g +32...).
+//
+// Raises
+//
+// - 400/invalid_country_code: The provided country code is invalid
+//
+// - 400/not_a_phone_number: The provided phone number is not recognised as one
+//
+// - 400/invalid_phone_number: The provided phone number has the correct format, but is symantically incorrect
+//
+// - 400/not_a_mobile_phone_number: The provided phone number is not a mobile number
 func ValidateAndFormatPhoneNumber(phoneNumber string, countryCode string) (string, *errors.GenericError) {
 
 	// This function will format any phoneNumber to its E164 representation (e.g +32...)
@@ -17,17 +27,17 @@ func ValidateAndFormatPhoneNumber(phoneNumber string, countryCode string) (strin
 
 	// If the parsing fails then it either means that the country code is required or the number is not valid at all
 	if err != nil {
-		if err.Error() == PhoneNumberInvalidCountryCodeMessage {
-			return "", errors.NewGenericError(400, errDomain, errSubDomain, errPhoneNumberInvalidCountry, nil)
+		if err.Error() == phoneNumberInvalidCountryCodeMessage {
+			return "", errors.NewGenericError(400, errorDomain, errorSubDomain, ErrorInvalidCountryCode, nil)
 		}
-		return "", errors.NewGenericError(400, errDomain, errSubDomain, errPhoneNumberNotAPhoneNumber, nil)
+		return "", errors.NewGenericError(400, errorDomain, errorSubDomain, ErrorNotAPhoneNumber, nil)
 	}
 	if !phonenumbers.IsValidNumber(parsedPhoneNumber) {
-		return "", errors.NewGenericError(400, errDomain, errSubDomain, errPhoneNumberInvalidPhoneNumber, nil)
+		return "", errors.NewGenericError(400, errorDomain, errorSubDomain, ErrorInvalidPhoneNumber, nil)
 	}
 	phoneType := phonenumbers.GetNumberType(parsedPhoneNumber)
 	if phoneType == phonenumbers.FIXED_LINE {
-		return "", errors.NewGenericError(400, errDomain, errSubDomain, errPhoneNumberNotAMobilePhoneNumber, nil)
+		return "", errors.NewGenericError(400, errorDomain, errorSubDomain, ErrorNotAMobilePhoneNumber, nil)
 	}
 	return phonenumbers.Format(parsedPhoneNumber, phonenumbers.E164), nil
 }

--- a/validation/phone_number_test.go
+++ b/validation/phone_number_test.go
@@ -18,12 +18,12 @@ func TestFormatPhoneNumber(t *testing.T) {
 		{"well formatted phone number BE without passing country code", "+32468300431", "", "+32468300431", ""},
 		{"Valid phone number FR", "06 23 83 96 79", "FR", "+33623839679", ""},
 		{"Valid phone number but not correctly formatted", "0468300431", "BE", "+32468300431", ""},
-		{"Valid phone number but not correctly formatted without passing country code", "0468300431", "", "", "invalid_country_code"},
-		{"Not Valid phone number", "0461", "BE", "", "invalid_phone_number"},
-		{"Valid phone number but not a mobile", "+3227896143", "BE", "", "not_a_mobile_phone_number"},
-		{"Not a phone number at all", "dhjdhj", "BE", "", "not_a_phone_number"},
-		{"Not a phone number at all without country code", "+324ER3643", "", "", "invalid_phone_number"},
-		{"Invalid phone number without country code", "+324780000012", "", "", "invalid_phone_number"},
+		{"Valid phone number but not correctly formatted without passing country code", "0468300431", "", "", ErrorInvalidCountryCode},
+		{"Not Valid phone number", "0461", "BE", "", ErrorInvalidPhoneNumber},
+		{"Valid phone number but not a mobile", "+3227896143", "BE", "", ErrorNotAMobilePhoneNumber},
+		{"Not a phone number at all", "dhjdhj", "BE", "", ErrorNotAPhoneNumber},
+		{"Not a phone number at all without country code", "+324ER3643", "", "", ErrorInvalidPhoneNumber},
+		{"Invalid phone number without country code", "+324780000012", "", "", ErrorInvalidPhoneNumber},
 	}
 
 	for _, tt := range tests {

--- a/validation/time.go
+++ b/validation/time.go
@@ -6,11 +6,11 @@ import (
 	"github.com/skiprco/go-utils/v2/errors"
 )
 
-// WithinTimeRange checks if the "nowTime" lies between "startTime" (including) and "endTime" (excluding).
+// WithinTimeRange checks if the "nowTime" is between "startTime" (including) and "endTime" (excluding).
 //
 // Raises
 //
-// - 400/end_time_before_start_time: Provided endTime lies before startTime
+// - 400/end_time_before_start_time: Provided endTime is before startTime
 func WithinTimeRange(nowTime time.Time, startTime time.Time, endTime time.Time) (bool, *errors.GenericError) {
 	// endTime should be after startTime
 	if endTime.Before(startTime) {
@@ -18,7 +18,7 @@ func WithinTimeRange(nowTime time.Time, startTime time.Time, endTime time.Time) 
 			"start_time": startTime.Format(time.RFC3339),
 			"end_time":   endTime.Format(time.RFC3339),
 		}
-		return false, errors.NewGenericError(400, "go-utils", "common", "end_time_before_start_time", meta)
+		return false, errors.NewGenericError(400, errorDomain, errorSubDomain, ErrorEndTimeBeforeStartTime, meta)
 	}
 
 	// Check if within time range

--- a/validation/time_test.go
+++ b/validation/time_test.go
@@ -50,6 +50,6 @@ func Test_WithinTimeRange_EndBeforeStart_Failure(t *testing.T) {
 	start := now.Add(time.Hour)
 	end := now
 	within, genErr := WithinTimeRange(now, start, end)
-	errors.AssertGenericError(t, genErr, 400, "end_time_before_start_time", nil)
+	errors.AssertGenericError(t, genErr, 400, ErrorEndTimeBeforeStartTime, nil)
 	assert.False(t, within)
 }

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -1,8 +1,0 @@
-package validation
-
-const errDomain = "go-utils"
-const errSubDomain = "common"
-const errPhoneNumberInvalidCountry = "invalid_country_code"
-const errPhoneNumberNotAPhoneNumber = "not_a_phone_number"
-const errPhoneNumberInvalidPhoneNumber = "invalid_phone_number"
-const errPhoneNumberNotAMobilePhoneNumber = "not_a_mobile_phone_number"


### PR DESCRIPTION
This PR:
1. Makes it very clear when calling a helper which errors could be returned
2. Allows easier matching on the error message. Since the error messages are exported, you can use below code:
```go
hasRole, genErr := auth.HasRole("OPERATOR", []string{})
if genErr != nil {
    if genErr.SubDomainCode == auth.ErrorUnknownRole {
        return errors.NewGenericError(...) // Our own custom error
   }
   return genErr
}
```