### PR TITLE
- converters : add currency and date converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ test := map[string]string{"<p>Key</p>": "<p>Value</p>"}
 converters.SanitizeObject(&test) // test == map[string]string{"Key": "Value"}
 ```
 
+#### Currency
+```go
+// convert a value in cent to a human readable price
+output, _ := converters.ConvertCentToCurrency(200, "EUR", "") // output == "2.00 €"
+// !! all currencies are not fully implemented
+```
+
+#### Date
+```go
+// convert a date in ISO format to an human readable date
+output, _ := ConvertToDate("2019-06-17T13:25:54.831Z", "EN") // output == "17/06/19"
+// !! all the language are not fully implemented
+```
+
 ### Errors
 ```go
 // Create an error with metadata

--- a/converters/common.go
+++ b/converters/common.go
@@ -1,0 +1,15 @@
+package converters
+
+import (
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+// return a printer with the expected language. If the language is not found or empty, return default language (English)
+func getPrinter(expectedLang string) *message.Printer {
+	lang := language.English
+	if expectedLang != "" {
+		lang = language.Make(expectedLang)
+	}
+	return message.NewPrinter(lang)
+}

--- a/converters/currency.go
+++ b/converters/currency.go
@@ -6,8 +6,8 @@ import (
 
 // ConvertCentToCurrency converts a cent value into a human readable price with the expected currency
 // decimal are managed by the expected lang
-// lang should have the 2 letters ISO format ("FR", "EN"). If the language is not found or empty, use English
-// the currency should be the ISO 4217 format ('EUR','USE'). If the currency doesn't implemented yet, return an error unknown_currency
+// lang should have the ISO 639-1 format ("fr", "en"). If the language is not found or empty, use English
+// the currency should be the ISO 4217 format ('EUR','USD'). If the currency doesn't implemented yet, return an error unknown_currency
 //
 // Raises
 //

--- a/converters/currency.go
+++ b/converters/currency.go
@@ -1,0 +1,34 @@
+package converters
+
+import (
+	"github.com/skiprco/go-utils/v2/errors"
+)
+
+// ConvertCentToCurrency converts a cent value into a human readable price with the expected currency
+// decimal are managed by the expected lang
+// lang should have the 2 letters ISO format ("FR", "EN"). If the language is not found or empty, use English
+// the currency should be the ISO 4217 format ('EUR','USE'). If the currency doesn't implemented yet, return an error unknown_currency
+//
+// Raises
+//
+// - 500/unknown_currency: The currency is unknown. If it's happened, extend the switch with the expected currency
+func ConvertCentToCurrency(cent int64, currency, lang string) (string, *errors.GenericError) {
+	printer := getPrinter(lang)
+	value := convertCentToUnitValue(cent)
+	switch currency {
+	case "EUR":
+		return printer.Sprintf("%.2f €", value), nil
+	case "USD":
+		return printer.Sprintf("$%.2f", value), nil
+	default:
+		meta := map[string]string{
+			"currency": currency,
+		}
+		return "", errors.NewGenericError(500, errorDomain, errorSubDomain, ErrorUnknownCurrency, meta)
+	}
+}
+
+// divide cent by 100 and return a float
+func convertCentToUnitValue(cent int64) float64 {
+	return float64(cent) / 100
+}

--- a/converters/currency_test.go
+++ b/converters/currency_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func Test_ConvertCentimeWithEnLanguageAndUSD_success(t *testing.T) {
-	result, genErr := ConvertCentToCurrency(200, "USD", "EN")
+	result, genErr := ConvertCentToCurrency(200, "USD", "en")
 	assert.Nil(t, genErr)
 	assert.Equal(t, "$2.00", result)
 }
 
 func Test_ConvertCentimeWithFRLanguageAndEUR_success(t *testing.T) {
-	result, genErr := ConvertCentToCurrency(200, "EUR", "FR")
+	result, genErr := ConvertCentToCurrency(200, "EUR", "fr")
 	assert.Nil(t, genErr)
 	assert.Equal(t, "2,00 €", result)
 }
@@ -25,7 +25,7 @@ func Test_ConvertCentimeWithUnknownLanguageAndEUR_success(t *testing.T) {
 }
 
 func Test_ConvertCentimeWithUnknownCurrency_failed500(t *testing.T) {
-	result, genErr := ConvertCentToCurrency(200, "OOO", "FR")
+	result, genErr := ConvertCentToCurrency(200, "OOO", "fr")
 	assert.NotNil(t, errors.NewGenericError(400, errorDomain, errorSubDomain, ErrorUnknownCurrency, map[string]string{"currency": "OOO"}), genErr)
 	assert.Equal(t, "", result)
 }

--- a/converters/currency_test.go
+++ b/converters/currency_test.go
@@ -1,0 +1,31 @@
+package converters
+
+import (
+	"github.com/skiprco/go-utils/v2/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_ConvertCentimeWithEnLanguageAndUSD_success(t *testing.T) {
+	result, genErr := ConvertCentToCurrency(200, "USD", "EN")
+	assert.Nil(t, genErr)
+	assert.Equal(t, "$2.00", result)
+}
+
+func Test_ConvertCentimeWithFRLanguageAndEUR_success(t *testing.T) {
+	result, genErr := ConvertCentToCurrency(200, "EUR", "FR")
+	assert.Nil(t, genErr)
+	assert.Equal(t, "2,00 €", result)
+}
+
+func Test_ConvertCentimeWithUnknownLanguageAndEUR_success(t *testing.T) {
+	result, genErr := ConvertCentToCurrency(200, "EUR", "")
+	assert.Nil(t, genErr)
+	assert.Equal(t, "2.00 €", result)
+}
+
+func Test_ConvertCentimeWithUnknownCurrency_failed500(t *testing.T) {
+	result, genErr := ConvertCentToCurrency(200, "OOO", "FR")
+	assert.NotNil(t, errors.NewGenericError(400, errorDomain, errorSubDomain, ErrorUnknownCurrency, map[string]string{"currency": "OOO"}), genErr)
+	assert.Equal(t, "", result)
+}

--- a/converters/date.go
+++ b/converters/date.go
@@ -1,0 +1,42 @@
+package converters
+
+import (
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/skiprco/go-utils/v2/errors"
+	"time"
+)
+
+// based on https://en.wikipedia.org/wiki/Date_format_by_country
+// sadly there is currently no go library to manage that. Probably not the best way to do that, but it should works until
+// Skipr a transcontinental company
+var dateFormats = map[string]dateFormat{
+	"FR":      {date: "02/01/06"},
+	"NL":      {date: "02-01-06"},
+	"EN":      {date: "02/01/06"},
+	"DEFAULT": {date: "02/01/06"},
+}
+
+type dateFormat struct {
+	date string
+}
+
+// ConvertToDate converts a string with a date of ISO format to a human readable date string formatted by the expected language
+//
+// Raises
+//
+// not error can be returned
+func ConvertToDate(date, lang string) (string, *errors.GenericError) {
+	format, found := dateFormats[lang]
+	if !found {
+		format = dateFormats["DEFAULT"]
+	}
+	printer := getPrinter(lang)
+	t, err := time.Parse(protocol.ISO8601TimeFormat, date)
+	if err != nil {
+		meta := map[string]string{
+			"date": date,
+		}
+		return "", errors.NewGenericError(500, errorDomain, errorSubDomain, ErrorCannotConvertDate, meta)
+	}
+	return printer.Sprint(t.Format(format.date)), nil
+}

--- a/converters/date.go
+++ b/converters/date.go
@@ -1,7 +1,6 @@
 package converters
 
 import (
-	"github.com/aws/aws-sdk-go/private/protocol"
 	"github.com/skiprco/go-utils/v2/errors"
 	"time"
 )
@@ -10,10 +9,10 @@ import (
 // sadly there is currently no go library to manage that. Probably not the best way to do that, but it should works until
 // Skipr a transcontinental company
 var dateFormats = map[string]dateFormat{
-	"FR":      {date: "02/01/06"},
-	"NL":      {date: "02-01-06"},
-	"EN":      {date: "02/01/06"},
-	"DEFAULT": {date: "02/01/06"},
+	"FR":      {date: "02/01/2006"},
+	"NL":      {date: "02-01-2006"},
+	"EN":      {date: "02/01/2006"},
+	"DEFAULT": {date: "02/01/2006"},
 }
 
 type dateFormat struct {
@@ -31,7 +30,7 @@ func ConvertToDate(date, lang string) (string, *errors.GenericError) {
 		format = dateFormats["DEFAULT"]
 	}
 	printer := getPrinter(lang)
-	t, err := time.Parse(protocol.ISO8601TimeFormat, date)
+	t, err := time.Parse(time.RFC3339, date)
 	if err != nil {
 		meta := map[string]string{
 			"date": date,

--- a/converters/date_test.go
+++ b/converters/date_test.go
@@ -9,19 +9,19 @@ import (
 func Test_ConvertDateForEn_success(t *testing.T) {
 	result, genErr := ConvertToDate("2019-06-17T13:25:54.831Z", "EN")
 	assert.Nil(t, genErr)
-	assert.Equal(t, "17/06/19", result)
+	assert.Equal(t, "17/06/2019", result)
 }
 
 func Test_ConvertDateForNL_success(t *testing.T) {
 	result, genErr := ConvertToDate("2021-05-09T13:25:54.831Z", "NL")
 	assert.Nil(t, genErr)
-	assert.Equal(t, "09-05-21", result)
+	assert.Equal(t, "09-05-2021", result)
 }
 
 func Test_ConvertDateForUnknownLanguage_success(t *testing.T) {
 	result, genErr := ConvertToDate("2021-05-09T13:25:54.831Z", "KK")
 	assert.Nil(t, genErr)
-	assert.Equal(t, "09/05/21", result)
+	assert.Equal(t, "09/05/2021", result)
 }
 
 func Test_ConvertDateForWithWrongFormat_success(t *testing.T) {

--- a/converters/date_test.go
+++ b/converters/date_test.go
@@ -1,0 +1,31 @@
+package converters
+
+import (
+	"github.com/skiprco/go-utils/v2/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_ConvertDateForEn_success(t *testing.T) {
+	result, genErr := ConvertToDate("2019-06-17T13:25:54.831Z", "EN")
+	assert.Nil(t, genErr)
+	assert.Equal(t, "17/06/19", result)
+}
+
+func Test_ConvertDateForNL_success(t *testing.T) {
+	result, genErr := ConvertToDate("2021-05-09T13:25:54.831Z", "NL")
+	assert.Nil(t, genErr)
+	assert.Equal(t, "09-05-21", result)
+}
+
+func Test_ConvertDateForUnknownLanguage_success(t *testing.T) {
+	result, genErr := ConvertToDate("2021-05-09T13:25:54.831Z", "KK")
+	assert.Nil(t, genErr)
+	assert.Equal(t, "09/05/21", result)
+}
+
+func Test_ConvertDateForWithWrongFormat_success(t *testing.T) {
+	result, genErr := ConvertToDate("2021-05-0913:25:54", "en")
+	assert.Equal(t, errors.NewGenericError(500, errorDomain, errorSubDomain, ErrorCannotConvertDate, map[string]string{"date": "2021-05-0913:25:54"}), genErr)
+	assert.Equal(t, "", result)
+}

--- a/converters/errors.go
+++ b/converters/errors.go
@@ -17,3 +17,10 @@ const ErrorPanicDuringSanitizeObject = "panic_during_sanitize_object"
 // ErrorFailedToNormaliseString indicates we failed to normalise the
 // provided string. More info is printed in the logs.
 const ErrorFailedToNormaliseString = "failed_to_normalise_string"
+
+// ErrorUnknownCurrency indicates the expected currency was not found
+const ErrorUnknownCurrency = "unknown_currency"
+
+// ErrorUnknownCurrency indicates the date param cannot be converted.
+// Probably related to a wrong format
+const ErrorCannotConvertDate = "cannot_convert_date"

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,7 @@ module github.com/skiprco/go-utils/v2
 go 1.14
 
 require (
-	github.com/aws/aws-sdk-go v1.34.28
 	github.com/gin-gonic/gin v1.6.3
-	github.com/klauspost/lctime v0.1.0
-	github.com/leekchan/accounting v1.0.0 // indirect
 	github.com/micro/go-micro/v2 v2.7.0
 	github.com/microcosm-cc/bluemonday v1.0.4
 	github.com/nyaruka/phonenumbers v1.0.60

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,10 @@ module github.com/skiprco/go-utils/v2
 go 1.14
 
 require (
+	github.com/aws/aws-sdk-go v1.34.28
 	github.com/gin-gonic/gin v1.6.3
+	github.com/klauspost/lctime v0.1.0
+	github.com/leekchan/accounting v1.0.0 // indirect
 	github.com/micro/go-micro/v2 v2.7.0
 	github.com/microcosm-cc/bluemonday v1.0.4
 	github.com/nyaruka/phonenumbers v1.0.60


### PR DESCRIPTION
Sadly I didn't find a library to get date format based of a language so I implemented formats by myself. This is not perfect but the important thing for me is the archetype of the fonction is correct and we can find a better solution when skipr will become a transcontinental company
for the currency, only € and $ are implemented but we can extend the implementation if required